### PR TITLE
Ajuste para permitir realizar o LoadStructure somente com os campos o…

### DIFF
--- a/src/core/DataSet.Serialize.JSON.Impl.pas
+++ b/src/core/DataSet.Serialize.JSON.Impl.pas
@@ -6,8 +6,6 @@ uses System.JSON, Data.DB, Language.Types, Providers.DataSet.Serialize, System.S
   System.SysUtils;
 
 type
-  ELoadFieldStructureException = class(Exception);
-
   TJSONSerialize = class
   private
     FMerging: Boolean;
@@ -376,46 +374,46 @@ end;
 
 function TJSONSerialize.LoadFieldStructure(const AJSONValue: TJSONValue): TFieldStructure;
 var
-  StrTemp: string;
-  IntTemp: Integer;
-  BoolTemp: Boolean;
+  LStrTemp: string;
+  LIntTemp: Integer;
+  LBoolTemp: Boolean;
 begin
-  if AJSONValue.TryGetValue<string>('DataType', StrTemp) then
-    Result.FieldType := TFieldType(GetEnumValue(TypeInfo(TFieldType), StrTemp))
+  if AJSONValue.TryGetValue<string>('DataType', LStrTemp) then
+    Result.FieldType := TFieldType(GetEnumValue(TypeInfo(TFieldType), LStrTemp))
   else
-    raise ELoadFieldStructureException.CreateFmt('Attribute %s not found in json!', ['DataType']);
+    raise EDataSetSerializeException.CreateFmt('Attribute %s not found in json!', ['DataType']);
 
-  if AJSONValue.TryGetValue<string>('FieldName', StrTemp) then
-    Result.FieldName := StrTemp
+  if AJSONValue.TryGetValue<string>('FieldName', LStrTemp) then
+    Result.FieldName := LStrTemp
   else
-    raise ELoadFieldStructureException.CreateFmt('Attribute %s not found in json!', ['FieldName']);
+    raise EDataSetSerializeException.CreateFmt('Attribute %s not found in json!', ['FieldName']);
 
-  if AJSONValue.TryGetValue<Integer>('Size', IntTemp) then
-    Result.Size := IntTemp;
+  if AJSONValue.TryGetValue<Integer>('Size', LIntTemp) then
+    Result.Size := LIntTemp;
 
-  if AJSONValue.TryGetValue<Integer>('Precision', IntTemp) then
-    Result.Precision := IntTemp;
+  if AJSONValue.TryGetValue<Integer>('Precision', LIntTemp) then
+    Result.Precision := LIntTemp;
 
-  if AJSONValue.TryGetValue<string>('Origin', StrTemp) then
-    Result.Origin := StrTemp;
+  if AJSONValue.TryGetValue<string>('Origin', LStrTemp) then
+    Result.Origin := LStrTemp;
 
-  if AJSONValue.TryGetValue<string>('DisplayLabel', StrTemp) then
-    Result.DisplayLabel := StrTemp;
+  if AJSONValue.TryGetValue<string>('DisplayLabel', LStrTemp) then
+    Result.DisplayLabel := LStrTemp;
 
-  if AJSONValue.TryGetValue<Boolean>('Key', BoolTemp) then
-    Result.Key := BoolTemp;
+  if AJSONValue.TryGetValue<Boolean>('Key', LBoolTemp) then
+    Result.Key := LBoolTemp;
 
-  if AJSONValue.TryGetValue<Boolean>('Required', BoolTemp) then
-    Result.Required := BoolTemp;
+  if AJSONValue.TryGetValue<Boolean>('Required', LBoolTemp) then
+    Result.Required := LBoolTemp;
 
-  if AJSONValue.TryGetValue<Boolean>('Visible', BoolTemp) then
-    Result.Visible := BoolTemp;
+  if AJSONValue.TryGetValue<Boolean>('Visible', LBoolTemp) then
+    Result.Visible := LBoolTemp;
 
-  if AJSONValue.TryGetValue<Boolean>('ReadOnly', BoolTemp) then
-    Result.ReadOnly := BoolTemp;
+  if AJSONValue.TryGetValue<Boolean>('ReadOnly', LBoolTemp) then
+    Result.ReadOnly := LBoolTemp;
 
-  if AJSONValue.TryGetValue<string>('AutoGenerateValue', StrTemp) then
-    Result.AutoGenerateValue := TAutoRefreshFlag(GetEnumValue(TypeInfo(TAutoRefreshFlag), StrTemp));
+  if AJSONValue.TryGetValue<string>('AutoGenerateValue', LStrTemp) then
+    Result.AutoGenerateValue := TAutoRefreshFlag(GetEnumValue(TypeInfo(TAutoRefreshFlag), LStrTemp));
 end;
 
 procedure TJSONSerialize.LoadStructure(const ADataSet: TDataSet);

--- a/src/core/DataSet.Serialize.JSON.Impl.pas
+++ b/src/core/DataSet.Serialize.JSON.Impl.pas
@@ -2,9 +2,12 @@
 
 interface
 
-uses System.JSON, Data.DB, Language.Types, Providers.DataSet.Serialize, System.StrUtils;
+uses System.JSON, Data.DB, Language.Types, Providers.DataSet.Serialize, System.StrUtils,
+  System.SysUtils;
 
 type
+  ELoadFieldStructureException = class(Exception);
+
   TJSONSerialize = class
   private
     FMerging: Boolean;
@@ -178,7 +181,7 @@ type
 
 implementation
 
-uses System.Classes, System.SysUtils, System.NetEncoding, System.TypInfo, System.DateUtils, Providers.DataSet.Serialize.Constants,
+uses System.Classes, System.NetEncoding, System.TypInfo, System.DateUtils, Providers.DataSet.Serialize.Constants,
   System.Generics.Collections, System.Variants, UpdatedStatus.Types,
   FireDAC.Comp.Client;
 
@@ -372,17 +375,47 @@ begin
 end;
 
 function TJSONSerialize.LoadFieldStructure(const AJSONValue: TJSONValue): TFieldStructure;
+var
+  StrTemp: string;
+  IntTemp: Integer;
+  BoolTemp: Boolean;
 begin
-  Result.FieldType := TFieldType(GetEnumValue(TypeInfo(TFieldType), AJSONValue.GetValue<string>('DataType')));
-  Result.Size := StrToIntDef(TJSONObject(AJSONValue).GetValue<string>('Size'), 0);
-  Result.FieldName := AJSONValue.GetValue<string>('FieldName');
-  Result.Origin := AJSONValue.GetValue<string>('Origin');
-  Result.DisplayLabel := AJSONValue.GetValue<string>('DisplayLabel');
-  Result.Key := AJSONValue.GetValue<Boolean>('Key');
-  Result.Required := AJSONValue.GetValue<Boolean>('Required');
-  Result.Visible := AJSONValue.GetValue<Boolean>('Visible');
-  Result.ReadOnly := AJSONValue.GetValue<Boolean>('ReadOnly');
-  Result.AutoGenerateValue := TAutoRefreshFlag(GetEnumValue(TypeInfo(TAutoRefreshFlag), AJSONValue.GetValue<string>('AutoGenerateValue')));
+  if AJSONValue.TryGetValue<string>('DataType', StrTemp) then
+    Result.FieldType := TFieldType(GetEnumValue(TypeInfo(TFieldType), StrTemp))
+  else
+    raise ELoadFieldStructureException.CreateFmt('Attribute %s not found in json!', ['DataType']);
+
+  if AJSONValue.TryGetValue<string>('FieldName', StrTemp) then
+    Result.FieldName := StrTemp
+  else
+    raise ELoadFieldStructureException.CreateFmt('Attribute %s not found in json!', ['FieldName']);
+
+  if AJSONValue.TryGetValue<Integer>('Size', IntTemp) then
+    Result.Size := IntTemp;
+
+  if AJSONValue.TryGetValue<Integer>('Precision', IntTemp) then
+    Result.Precision := IntTemp;
+
+  if AJSONValue.TryGetValue<string>('Origin', StrTemp) then
+    Result.Origin := StrTemp;
+
+  if AJSONValue.TryGetValue<string>('DisplayLabel', StrTemp) then
+    Result.DisplayLabel := StrTemp;
+
+  if AJSONValue.TryGetValue<Boolean>('Key', BoolTemp) then
+    Result.Key := BoolTemp;
+
+  if AJSONValue.TryGetValue<Boolean>('Required', BoolTemp) then
+    Result.Required := BoolTemp;
+
+  if AJSONValue.TryGetValue<Boolean>('Visible', BoolTemp) then
+    Result.Visible := BoolTemp;
+
+  if AJSONValue.TryGetValue<Boolean>('ReadOnly', BoolTemp) then
+    Result.ReadOnly := BoolTemp;
+
+  if AJSONValue.TryGetValue<string>('AutoGenerateValue', StrTemp) then
+    Result.AutoGenerateValue := TAutoRefreshFlag(GetEnumValue(TypeInfo(TAutoRefreshFlag), StrTemp));
 end;
 
 procedure TJSONSerialize.LoadStructure(const ADataSet: TDataSet);

--- a/src/providers/Providers.DataSet.Serialize.pas
+++ b/src/providers/Providers.DataSet.Serialize.pas
@@ -1,5 +1,6 @@
 unit Providers.DataSet.Serialize;
-
+
+
 interface
 
 uses System.DateUtils, System.JSON, Data.DB, BooleanField.Types, System.SysUtils;
@@ -21,6 +22,7 @@ type
   TFieldStructure = record
     FieldType: TFieldType;
     Size: Integer;
+    Precision: Integer;
     FieldName: string;
     Origin: string;
     DisplayLabel: string;
@@ -139,6 +141,16 @@ begin
   Result.DataSet := ADataSet;
   Result.Name := CreateValidIdentifier(ADataSet.Name + Result.FieldName);
   Result.Size := AFieldStructure.Size;
+
+  if Result is TBCDField then
+    TBCDField(Result).Precision := AFieldStructure.Precision
+  else if Result is TFloatField then
+    TFloatField(Result).Precision := AFieldStructure.Precision
+  else if Result is TSingleField then
+    TSingleField(Result).Precision := AFieldStructure.Precision
+  else if Result is TExtendedField then
+    TExtendedField(Result).Precision := AFieldStructure.Precision;
+
   Result.Visible := AFieldStructure.Visible;
   Result.ReadOnly := AFieldStructure.ReadOnly;
   Result.Required := AFieldStructure.Required;
@@ -160,4 +172,4 @@ begin
 end;
 
 end.
-
+

--- a/src/providers/Providers.DataSet.Serialize.pas
+++ b/src/providers/Providers.DataSet.Serialize.pas
@@ -1,6 +1,5 @@
 unit Providers.DataSet.Serialize;
-
-
+
 interface
 
 uses System.DateUtils, System.JSON, Data.DB, BooleanField.Types, System.SysUtils;
@@ -150,7 +149,7 @@ begin
     TSingleField(Result).Precision := AFieldStructure.Precision
   else if Result is TExtendedField then
     TExtendedField(Result).Precision := AFieldStructure.Precision;
-
+  
   Result.Visible := AFieldStructure.Visible;
   Result.ReadOnly := AFieldStructure.ReadOnly;
   Result.Required := AFieldStructure.Required;
@@ -172,4 +171,4 @@ begin
 end;
 
 end.
-
+


### PR DESCRIPTION
Foi alterado o método que realiza a leitura da estrutura do dataset. Ao invés de usar o GetValue para extrair os valores (o que causa uma exceção caso a chave não seja encontrada no JSON) pelo TryGetValue, onde são validados caso a chave exista.
Foi alterado também para realizar a leitura da "precision" para campos do tipo flutuante.