### PR TITLE
I can set null

### DIFF
--- a/src/core/DataSet.Serialize.DS.Impl.pas
+++ b/src/core/DataSet.Serialize.DS.Impl.pas
@@ -140,7 +140,7 @@ begin
     Exit;
   for LField in ADataSet.Fields do
   begin
-    if (not LField.Visible) or LField.IsNull or LField.AsString.Trim.IsEmpty then
+    if not(LField.Visible) then
       Continue;
     LKey := LowerCase(LField.FieldName);
     case LField.DataType of


### PR DESCRIPTION
The validation if the field IsNull or an empty string is invalid, because the dataset doens't work if I want to clear some field in my table, so, take all the dataset structure, except the invisible one.

The JSON to DataSet already brief null values and clear the fields when this ocurrs.