### PR TITLE
function-adjustment

### DIFF
--- a/src/core/DataSet.Serialize.Import.pas
+++ b/src/core/DataSet.Serialize.Import.pas
@@ -267,7 +267,7 @@ begin
             Continue;
         if LField.ReadOnly then
           Continue;
-        if not AJSONObject.TryGetValue(TDataSetSerializeUtils.NameToLowerCamelCase(LField.FieldName), LJSONValue) then
+        if not (AJSONObject.TryGetValue(TDataSetSerializeUtils.NameToLowerCamelCase(LField.FieldName), LJSONValue) or (AJSONObject.TryGetValue(LField.FieldName, LJSONValue))) then
           Continue;
         if LJSONValue is TJSONNull then
         begin

--- a/src/core/DataSet.Serialize.Import.pas
+++ b/src/core/DataSet.Serialize.Import.pas
@@ -204,7 +204,7 @@ begin
   begin
     if not(ADataSet is TFDMemTable)  then
       Exit;
-    if ADataSet.FieldCount = 0 then
+    if ADataSet.FieldDefs.Count = 0 then
       LoadFieldsFromJSON(ADataSet, AJSONObject);
     ADataSet.Open;
   end;

--- a/src/providers/DataSet.Serialize.Utils.pas
+++ b/src/providers/DataSet.Serialize.Utils.pas
@@ -139,7 +139,7 @@ var
 begin
   Result := EmptyStr;
   if not TDataSetSerializeConfig.GetInstance.LowerCamelCase then
-    Exit(AFieldName);
+    Exit(AFieldName.ToLower);
   LUnderline := False;
   for I := 1 to AFieldName.Length do
   begin

--- a/src/providers/DataSet.Serialize.Utils.pas
+++ b/src/providers/DataSet.Serialize.Utils.pas
@@ -139,7 +139,7 @@ var
 begin
   Result := EmptyStr;
   if not TDataSetSerializeConfig.GetInstance.LowerCamelCase then
-    Exit(AFieldName.ToLower);
+    Exit(AFieldName);
   LUnderline := False;
   for I := 1 to AFieldName.Length do
   begin


### PR DESCRIPTION
If the LowerCamelCase property is false, the field name was changed to lowercase.

Unit DataSet.Serialize.Import, line 270.
When obtaining the value was not found.

Reason: If JSON's Field is Capitalized it was not found.

![image](https://user-images.githubusercontent.com/54585337/88072861-ec8ef900-cb4b-11ea-818e-64a818d81510.png)
