### PR TITLE
adjusted-functions-date-time

### DIFF
--- a/src/core/DataSet.Serialize.Export.pas
+++ b/src/core/DataSet.Serialize.Export.pas
@@ -170,14 +170,14 @@ begin
         Result.AddPair(LKey, TJSONNumber.Create(LField.AsFloat));
       TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid:
         Result.AddPair(LKey, TJSONString.Create(LField.AsWideString));
-      TFieldType.ftDate:
-        Result.AddPair(LKey, TJSONString.Create(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatDate, LField.AsDateTime)));
       TFieldType.ftDateTime:
-        Result.AddPair(LKey, TJSONString.Create(DateToISO8601(LField.AsDateTime, TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
-      TFieldType.ftTime:
-        Result.AddPair(LKey, TJSONString.Create(SQLTimeStampToStr('hh:nn:ss', LField.AsSQLTimeStamp)));
-      TFieldType.ftTimeStamp:
-        Result.AddPair(LKey, TJSONString.Create(DateToISO8601(SQLTimeStampToDateTime(LField.AsSQLTimeStamp),TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
+           Result.AddPair(LKey, TJSONString.Create(FormatDateTime('c', LField.AsDateTime)));
+       TFieldType.ftTimeStamp:
+           Result.AddPair(LKey, TJSONString.Create(DateToISO8601(LField.AsDateTime, TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
+       TFieldType.ftTime:
+           Result.AddPair(LKey, TJSONString.Create(FormatDateTime('tt', LField.AsDateTime)));
+       TFieldType.ftDate:
+           Result.AddPair(LKey, TJSONString.Create(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatDate, LField.AsDateTime)));
       TFieldType.ftCurrency:
         begin
           if TDataSetSerializeConfig.GetInstance.Export.FormatCurrency.Trim.IsEmpty then

--- a/src/core/DataSet.Serialize.Export.pas
+++ b/src/core/DataSet.Serialize.Export.pas
@@ -89,7 +89,7 @@ type
 
 implementation
 
-uses DataSet.Serialize.BooleanField, System.DateUtils, Data.FmtBcd, Data.SqlTimSt, System.SysUtils, DataSet.Serialize.Utils, System.TypInfo,
+uses DataSet.Serialize.BooleanField, System.DateUtils, Data.FmtBcd, System.SysUtils, DataSet.Serialize.Utils, System.TypInfo,
   DataSet.Serialize.Consts, System.Classes, System.NetEncoding, System.Generics.Collections, FireDAC.Comp.DataSet,
   DataSet.Serialize.UpdatedStatus, DataSet.Serialize.Config;
 

--- a/src/core/DataSet.Serialize.Export.pas
+++ b/src/core/DataSet.Serialize.Export.pas
@@ -89,7 +89,7 @@ type
 
 implementation
 
-uses DataSet.Serialize.BooleanField, System.DateUtils, Data.FmtBcd, System.SysUtils, DataSet.Serialize.Utils, System.TypInfo,
+uses DataSet.Serialize.BooleanField, System.DateUtils, Data.FmtBcd, Data.SqlTimSt, System.SysUtils, DataSet.Serialize.Utils, System.TypInfo,
   DataSet.Serialize.Consts, System.Classes, System.NetEncoding, System.Generics.Collections, FireDAC.Comp.DataSet,
   DataSet.Serialize.UpdatedStatus, DataSet.Serialize.Config;
 
@@ -170,10 +170,14 @@ begin
         Result.AddPair(LKey, TJSONNumber.Create(LField.AsFloat));
       TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid:
         Result.AddPair(LKey, TJSONString.Create(LField.AsWideString));
-      TFieldType.ftTimeStamp, TFieldType.ftDateTime, TFieldType.ftTime:
-        Result.AddPair(LKey, TJSONString.Create(DateToISO8601(LField.AsDateTime, TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
       TFieldType.ftDate:
         Result.AddPair(LKey, TJSONString.Create(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatDate, LField.AsDateTime)));
+      TFieldType.ftDateTime:
+        Result.AddPair(LKey, TJSONString.Create(DateToISO8601(LField.AsDateTime, TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
+      TFieldType.ftTime:
+        Result.AddPair(LKey, TJSONString.Create(SQLTimeStampToStr('hh:nn:ss', LField.AsSQLTimeStamp)));
+      TFieldType.ftTimeStamp:
+        Result.AddPair(LKey, TJSONString.Create(DateToISO8601(SQLTimeStampToDateTime(LField.AsSQLTimeStamp),TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
       TFieldType.ftCurrency:
         begin
           if TDataSetSerializeConfig.GetInstance.Export.FormatCurrency.Trim.IsEmpty then

--- a/src/core/DataSet.Serialize.Import.pas
+++ b/src/core/DataSet.Serialize.Import.pas
@@ -288,8 +288,12 @@ begin
             LField.AsFloat := StrToFloat(LJSONValue.Value);
           TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid:
             LField.AsString := LJSONValue.Value;
-          TFieldType.ftDate, TFieldType.ftTimeStamp, TFieldType.ftDateTime, TFieldType.ftTime:
+          TFieldType.ftDate:
+            LField.AsDateTime := EncodeDate(StrToInt(Copy(LJSONValue.Value, 1, 4)), StrToInt(Copy(LJSONValue.Value, 6, 2)), StrToInt(Copy(LJSONValue.Value, 9, 2)));
+          TFieldType.ftDateTime:
             LField.AsDateTime := ISO8601ToDate(LJSONValue.Value, TDataSetSerializeConfig.GetInstance.DateInputIsUTC);
+          TFieldType.ftTimeStamp, TFieldType.ftTime:
+            LField.AsDateTime := EncodeTime(StrToInt(Copy(LJSONValue.Value, 1, 2)), StrToInt(Copy(LJSONValue.Value, 4, 2)), StrToInt(Copy(LJSONValue.Value, 7, 2)), 0);
           TFieldType.ftDataSet:
             begin
               LNestedDataSet := TDataSetField(LField).NestedDataSet;

--- a/src/core/DataSet.Serialize.Import.pas
+++ b/src/core/DataSet.Serialize.Import.pas
@@ -289,11 +289,11 @@ begin
           TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid:
             LField.AsString := LJSONValue.Value;
           TFieldType.ftDate:
-            LField.AsDateTime := EncodeDate(StrToInt(Copy(LJSONValue.Value, 1, 4)), StrToInt(Copy(LJSONValue.Value, 6, 2)), StrToInt(Copy(LJSONValue.Value, 9, 2)));
-          TFieldType.ftDateTime:
-            LField.AsDateTime := ISO8601ToDate(LJSONValue.Value, TDataSetSerializeConfig.GetInstance.DateInputIsUTC);
-          TFieldType.ftTimeStamp, TFieldType.ftTime:
-            LField.AsDateTime := EncodeTime(StrToInt(Copy(LJSONValue.Value, 1, 2)), StrToInt(Copy(LJSONValue.Value, 4, 2)), StrToInt(Copy(LJSONValue.Value, 7, 2)), 0);
+             LField.AsDateTime := DateOf(ISO8601ToDate(LJSONValue.Value, TDataSetSerializeConfig.GetInstance.DateInputIsUTC));
+          TFieldType.ftTimeStamp, TFieldType.ftDateTime:
+             LField.AsDateTime := ISO8601ToDate(LJSONValue.Value, TDataSetSerializeConfig.GetInstance.DateInputIsUTC);
+          TFieldType.ftTime:
+             LField.AsDateTime := StrToTime(LJSONValue.Value);
           TFieldType.ftDataSet:
             begin
               LNestedDataSet := TDataSetField(LField).NestedDataSet;


### PR DESCRIPTION
Quando a field era do tipo time, no json sempre tinha a uma data informada!
Foi ajustado de forma que: 

Tipo da Field = Data - então o valor é uma data normal..
Tipo da Field = Time - então o valor é um time normal..
Se for DataTime - aí sim entra o formato do ISO8601.