### PR TITLE
Fixes bug on android that triggers the destroy event and generates ac…

### DIFF
--- a/src/singletons/DataSet.Serialize.Config.pas
+++ b/src/singletons/DataSet.Serialize.Config.pas
@@ -42,7 +42,6 @@ type
     property &Export: TDataSetSerializeConfigExport read FExport write FExport;
     property Import: TDataSetSerializeConfigImport read FImport write FImport;
     class function GetInstance: TDataSetSerializeConfig;
-    class function NewInstance: TObject; override;
     destructor Destroy; override;
   end;
 
@@ -74,14 +73,9 @@ end;
 
 class function TDataSetSerializeConfig.GetInstance: TDataSetSerializeConfig;
 begin
-  Result := TDataSetSerializeConfig.Create;
-end;
-
-class function TDataSetSerializeConfig.NewInstance: TObject;
-begin
   if not Assigned(Instancia) then
   begin
-    Instancia := TDataSetSerializeConfig(inherited NewInstance);
+    Instancia := TDataSetSerializeConfig.Create;
     Instancia.LowerCamelCase := True;
     Instancia.DataSetPrefix := ['mt', 'qry'];
     Instancia.DateInputIsUTC := True;


### PR DESCRIPTION
Utilizando em uma aplicação mobile, no meu caso no android, estava chamando o evento destroy da classe TDataSetSerializeConfig, destruindo assim a instancia dos objetos das propriedades Export e Import, porém a var Instancia continuava na memória, e se na sequencia tentar acessar algumas dessas duas propriedades ocorria um access violation.
Migrando o código para o método GetInstance resolveu o problema.