### PR TITLE
DateToISO8601

### DIFF
--- a/src/DataSet.Serialize.Export.pas
+++ b/src/DataSet.Serialize.Export.pas
@@ -164,9 +164,7 @@ begin
             Result.Add(ADataSet.Fields[0].AsLargeInt);
           TFieldType.ftSingle, TFieldType.ftFloat:
             Result.Add(ADataSet.Fields[0].AsFloat);
-          TFieldType.ftDateTime:
-               Result.Add(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatDateTime, ADataSet.Fields[0].AsDateTime));
-           TFieldType.ftTimeStamp:
+           TFieldType.ftTimeStamp, TFieldType.ftDateTime:
                Result.Add(DateToISO8601(ADataSet.Fields[0].AsDateTime, TDataSetSerializeConfig.GetInstance.DateInputIsUTC));
            TFieldType.ftTime:
                Result.Add(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatTime, ADataSet.Fields[0].AsDateTime));
@@ -239,9 +237,7 @@ begin
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsFloat{$ELSE}TJSONNumber.Create(LField.AsFloat){$ENDIF});
       TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid, TFieldType.ftFixedChar, TFieldType.ftFixedWideChar:
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(LField.AsWideString));
-      TFieldType.ftDateTime:
-           Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatDateTime, LField.AsDateTime)));
-       TFieldType.ftTimeStamp:
+       TFieldType.ftTimeStamp, TFieldType.ftDateTime:
            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(DateToISO8601(LField.AsDateTime, TDataSetSerializeConfig.GetInstance.DateInputIsUTC)));
        TFieldType.ftTime:
            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(FormatDateTime(TDataSetSerializeConfig.GetInstance.Export.FormatTime, LField.AsDateTime)));


### PR DESCRIPTION
Exportação de Data e Hora unificada (ftTimeStamp, ftDateTime) para formato DateToISO8601, na versão Delphi CE 10.4.2 durante a importação ocorria erro de String date invalid!, já que já havia a unificação na unit de importação