### PR TITLE
Adicionado a opção de trazer campos blobs sem o encodeBase64

### DIFF
--- a/src/DataSet.Serialize.Export.pas
+++ b/src/DataSet.Serialize.Export.pas
@@ -20,6 +20,7 @@ type
     FOnlyUpdatedRecords: Boolean;
     FChildRecord: Boolean;
     FValueRecord: Boolean;
+    FEncodeBase64Blob  : Boolean;
     /// <summary>
     ///   Creates a JSON object with the data from the current record of DataSet.
     /// </summary>
@@ -54,7 +55,7 @@ type
     /// <remarks>
     ///   Invisible or null fields will not be exported.
     /// </remarks>
-    function DataSetToJSONArray(const ADataSet: TDataSet; const IsChild: Boolean; const IsValue: Boolean = True): TJSONArray;
+    function DataSetToJSONArray(const ADataSet: TDataSet; const IsChild: Boolean; const IsValue: Boolean = True; isEncodeBlob : boolean = true): TJSONArray;
     /// <summary>
     ///   Encrypts a blob field in Base64.
     /// </summary>
@@ -79,7 +80,7 @@ type
     /// <summary>
     ///   Responsible for creating a new instance of TDataSetSerialize class.
     /// </summary>
-    constructor Create(const ADataSet: TDataSet; const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; const AValueRecords: Boolean = True);
+    constructor Create(const ADataSet: TDataSet; const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; const AValueRecords: Boolean = True; AEncodeBase64Blob : boolean = true);
     /// <summary>
     ///   Creates an array of JSON objects with all DataSet records.
     /// </summary>
@@ -116,9 +117,9 @@ implementation
 
 uses
 {$IF DEFINED(FPC)}
-  DateUtils, SysUtils, Classes, FmtBCD, TypInfo, base64,
+  DateUtils, SysUtils, Classes, FmtBCD, TypInfo, base64, StrUtils,
 {$ELSE}
-  System.DateUtils, Data.FmtBcd, System.SysUtils, System.TypInfo, System.Classes, System.NetEncoding, System.Generics.Collections,
+  System.DateUtils, Data.FmtBcd, System.SysUtils, System.StrUtils, System.TypInfo, System.Classes, System.NetEncoding, System.Generics.Collections,
   FireDAC.Comp.DataSet,
 {$ENDIF}
   DataSet.Serialize.Utils, DataSet.Serialize.Consts, DataSet.Serialize.UpdatedStatus, DataSet.Serialize.Config;
@@ -130,7 +131,7 @@ begin
   Result := DataSetToJSONObject(FDataSet);
 end;
 
-function TDataSetSerialize.DataSetToJSONArray(const ADataSet: TDataSet; const IsChild: Boolean; const IsValue: Boolean = True): TJSONArray;
+function TDataSetSerialize.DataSetToJSONArray(const ADataSet: TDataSet; const IsChild: Boolean; const IsValue: Boolean = True; isEncodeBlob : boolean = true): TJSONArray;
 var
   LBookMark: TBookmark;
 begin
@@ -182,7 +183,12 @@ begin
           TFieldType.ftFMTBcd, TFieldType.ftBCD:
             Result.Add(BcdToDouble(ADataSet.Fields[0].AsBcd));
           TFieldType.ftGraphic, TFieldType.ftBlob, TFieldType.ftOraBlob, TFieldType.ftStream:
-            Result.Add(EncodingBlobField(ADataSet.Fields[0]));
+          begin
+            if isEncodeBlob then
+              Result.Add(EncodingBlobField(ADataSet.Fields[0]))
+            else
+              Result.Add(ADataSet.Fields[0].AsString); // Daniel:  return original byte in string
+          end;
           else
             raise EDataSetSerializeException.CreateFmt(FIELD_TYPE_NOT_FOUND, [ADataSet.Fields[0].FieldName]);
         end;
@@ -262,7 +268,7 @@ begin
         end;
       {$ENDIF}
       TFieldType.ftGraphic, TFieldType.ftBlob, TFieldType.ftOraBlob{$IF NOT DEFINED(FPC)}, TFieldType.ftStream{$ENDIF}:
-        Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(EncodingBlobField(LField)));
+        Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create( ifthen(FEncodeBase64Blob,EncodingBlobField(LField),LField.AsString)));
       else
         raise EDataSetSerializeException.CreateFmt(FIELD_TYPE_NOT_FOUND, [LKey]);
     end;
@@ -426,17 +432,18 @@ begin
   end;
 end;
 
-constructor TDataSetSerialize.Create(const ADataSet: TDataSet; const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; const AValueRecords: Boolean = True);
+constructor TDataSetSerialize.Create(const ADataSet: TDataSet; const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; const AValueRecords: Boolean = True; AEncodeBase64Blob : boolean = true);
 begin
   FDataSet := ADataSet;
   FOnlyUpdatedRecords := AOnlyUpdatedRecords;
   FChildRecord := AChildRecords;
   FValueRecord := AValueRecords;
+  FEncodeBase64Blob   := AEncodeBase64Blob;
 end;
 
 function TDataSetSerialize.ToJSONArray: TJSONArray;
 begin
-  Result := DataSetToJSONArray(FDataSet, FChildRecord, FValueRecord);
+  Result := DataSetToJSONArray(FDataSet, FChildRecord, FValueRecord, FEncodeBase64Blob);
 end;
 
 end.

--- a/src/DataSet.Serialize.pas
+++ b/src/DataSet.Serialize.pas
@@ -96,7 +96,7 @@ type
     /// <remarks>
     ///   Invisible fields will not be generated.
     /// </remarks>
-    function ToJSONArray(const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; AValueRecords: Boolean = True): TJSONArray;
+    function ToJSONArray(const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; AValueRecords: Boolean = True; AEncodeBase64Blob : Boolean = true): TJSONArray;
     /// <summary>
     ///   Responsible for exporting the structure of a DataSet in JSON Array format.
     /// </summary>
@@ -229,11 +229,11 @@ uses
 {$ENDIF}
   DataSet.Serialize.Export, DataSet.Serialize.Import;
 
-function TDataSetSerializeHelper.ToJSONArray(const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; AValueRecords: Boolean = True): TJSONArray;
+function TDataSetSerializeHelper.ToJSONArray(const AOnlyUpdatedRecords: Boolean = False; const AChildRecords: Boolean = True; AValueRecords: Boolean = True; AEncodeBase64Blob : Boolean = true): TJSONArray;
 var
   LDataSetSerialize: TDataSetSerialize;
 begin
-  LDataSetSerialize := TDataSetSerialize.Create(Self, AOnlyUpdatedRecords, AChildRecords, AValueRecords);
+  LDataSetSerialize := TDataSetSerialize.Create(Self, AOnlyUpdatedRecords, AChildRecords, AValueRecords, AEncodeBase64Blob);
   try
     Result := LDataSetSerialize.ToJSONArray;
   finally


### PR DESCRIPTION
Em uma rotina, surgiu a nescessidade de ter o retorno do metodo ToJSONArray, sem o encode EncodingBlobField, criei uma pequena rotina para ter a possibilidade de trazer sem o encode.