### PR TITLE
Bug Variant or safe array index out of bounds

### DIFF
--- a/src/DataSet.Serialize.Import.pas
+++ b/src/DataSet.Serialize.Import.pas
@@ -220,6 +220,7 @@ var
   {$ENDIF}
   LObjectState: string;
   LFormatSettings: TFormatSettings;
+  LKeyValues: TKeyValues;
 begin
   if (not Assigned(AJSONObject)) or (not Assigned(ADataSet)) or (AJSONObject.Count = 0) then
     Exit;
@@ -263,8 +264,12 @@ begin
           TFDDataSet(ADataSet).MasterSource := nil;
         end;
         {$ENDIF}
-        if not ADataSet.Locate(GetKeyFieldsDataSet(ADataSet), VarArrayOf(GetKeyValuesDataSet(ADataSet, AJSONObject)), []) then
-          Exit;
+        LKeyValues := GetKeyValuesDataSet(ADataSet, AJSONObject);
+        if (Length(LKeyValues) = 0) or (not ADataSet.Locate(GetKeyFieldsDataSet(ADataSet), VarArrayOf(LKeyValues), [])) then
+        begin
+          if ADataSet.State <> dsInsert then
+            ADataSet.Append;
+        end;
         if TUpdateStatus.usModified.ToString = LObjectState then
         begin
           if ADataSet.State <> dsEdit then


### PR DESCRIPTION
- When you send a modified register and this regist does not exists on dataset you got this error.
- Now dataset.serialize try to insert this register.