### PR TITLE
TJSONObject Dentro do TJSONArray - FK (1..1)

### DIFF
--- a/src/DataSet.Serialize.Import.pas
+++ b/src/DataSet.Serialize.Import.pas
@@ -340,6 +340,11 @@ begin
           LField.Text := LJSONValue.Value;
           Continue;
         end;
+        if LJSONValue is TJSONObject then
+        begin
+          LField.Text := LJSONValue.ToJSON;
+          Continue;
+        end;
         case LField.DataType of
           TFieldType.ftBoolean:
             begin

--- a/src/DataSet.Serialize.Import.pas
+++ b/src/DataSet.Serialize.Import.pas
@@ -340,11 +340,6 @@ begin
           LField.Text := LJSONValue.Value;
           Continue;
         end;
-        if LJSONValue is TJSONObject then
-        begin
-          LField.Text := LJSONValue.ToJSON;
-          Continue;
-        end;
         case LField.DataType of
           TFieldType.ftBoolean:
             begin
@@ -393,7 +388,12 @@ begin
                 LField.AsFloat := LTryStrToFloat;
             end;
           TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftGuid, TFieldType.ftFixedChar, TFieldType.ftFixedWideChar:
-            LField.AsString := LJSONValue.Value;
+          begin
+            if LJSONValue is TJSONObject then
+              LField.Text := LJSONValue.ToJSON
+            else
+              LField.AsString := LJSONValue.Value;
+          end;
           TFieldType.ftDate:
             begin
               if LJsonValue.InheritsFrom(TJSONNumber) then


### PR DESCRIPTION
Quando temos um relacionamento de 1..1 (FK) entre as entidades o DataSet.Serialize.Import não retorna o valor do TJSONObject aninhado, pois para esse LJSONValue não existe o .Value e sim um .ToString.

Exemplo:
`[
	{
		"id": 10,
		"date": "2023-02-18",
		"hour": "18:00:00.000",
		"resultTeamA": 0,
		"resultTeamB": 0,
		"status": true,
		"teamA": {
			"id": 28,
			"name": "PALMEIRAS"
		},
		"teamB": {
			"id": 29,
			"name": "FLAMENGO"
		}
	}
]`