### PR TITLE
Feat export format

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ TDataSetSerializeConfig.GetInstance.DateInputIsUTC := True;
 ```pascal
   TDataSetSerializeConfig.GetInstance.Export.ExportChildDataSetAsJsonObject := False;
 ```
+* Export Largeint as string
+```pascal
+  TDataSetSerializeConfig.GetInstance.Export.ExportLargeintAsString := False;
+```
+* Export BCD as float
+```pascal
+  TDataSetSerializeConfig.GetInstance.Export.ExportBCDAsFloat := False;
+```
 * Import only fields visible
 ```pascal
   TDataSetSerializeConfig.GetInstance.Import.ImportOnlyFieldsVisible := True;

--- a/src/DataSet.Serialize.Config.pas
+++ b/src/DataSet.Serialize.Config.pas
@@ -11,6 +11,7 @@ type
 
   TDataSetSerializeConfigExport = class
   private
+    FExportLargeintAsString: boolean;      
     FExportNullValues: Boolean;
     FExportNullAsEmptyString: Boolean;
     FExportOnlyFieldsVisible: Boolean;
@@ -41,6 +42,7 @@ type
     property DecimalSeparator: Char read FDecimalSeparator write FDecimalSeparator;
     property ExportFloatScientificNotation: Boolean read FExportFloatScientificNotation write FExportFloatScientificNotation;
     {$ENDIF}
+    property ExportLargeintAsString: boolean read FExportLargeintAsString write FExportLargeintAsString;
   end;
 
   TDataSetSerializeConfigImport = class
@@ -151,6 +153,7 @@ begin
   FDecimalSeparator := '.';
   FExportFloatScientificNotation := False;
   {$ENDIF}
+  FExportLargeintAsString := False;
 end;
 
 { TDataSetSerializeConfigImport }

--- a/src/DataSet.Serialize.Config.pas
+++ b/src/DataSet.Serialize.Config.pas
@@ -11,6 +11,7 @@ type
 
   TDataSetSerializeConfigExport = class
   private
+    FExportBCDAsFloat: boolean;
     FExportLargeintAsString: boolean;      
     FExportNullValues: Boolean;
     FExportNullAsEmptyString: Boolean;
@@ -43,6 +44,7 @@ type
     property ExportFloatScientificNotation: Boolean read FExportFloatScientificNotation write FExportFloatScientificNotation;
     {$ENDIF}
     property ExportLargeintAsString: boolean read FExportLargeintAsString write FExportLargeintAsString;
+    property ExportBCDAsFloat: boolean read FExportBCDAsFloat write FExportBCDAsFloat;   
   end;
 
   TDataSetSerializeConfigImport = class
@@ -154,6 +156,7 @@ begin
   FExportFloatScientificNotation := False;
   {$ENDIF}
   FExportLargeintAsString := False;
+  FExportBCDAsFloat := False;                
 end;
 
 { TDataSetSerializeConfigImport }

--- a/src/DataSet.Serialize.Export.pas
+++ b/src/DataSet.Serialize.Export.pas
@@ -291,7 +291,12 @@ begin
       TFieldType.ftInteger, TFieldType.ftSmallint, TFieldType.ftAutoInc{$IF NOT DEFINED(FPC)}, TFieldType.ftShortint, TFieldType.ftLongWord, TFieldType.ftWord, TFieldType.ftByte{$ENDIF}:
         Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsInteger{$ELSE}TJSONNumber.Create(LField.AsInteger){$ENDIF});
       TFieldType.ftLargeint:
-        Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsLargeInt{$ELSE}TJSONNumber.Create(LField.AsLargeInt){$ENDIF});
+        begin
+          if TDataSetSerializeConfig.GetInstance.Export.ExportLargeintAsString then
+            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsLargeInt.ToString{$ELSE}TJSONString.Create(LField.AsLargeInt.ToString){$ENDIF})
+          else
+            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}LField.AsLargeInt{$ELSE}TJSONNumber.Create(LField.AsLargeInt){$ENDIF});
+        end; 
       {$IF NOT DEFINED(FPC)}TFieldType.ftSingle, TFieldType.ftExtended, {$ENDIF}TFieldType.ftFloat:
         begin
           if TDataSetSerializeConfig.GetInstance.Export.FormatFloat.Trim.IsEmpty then

--- a/src/DataSet.Serialize.Export.pas
+++ b/src/DataSet.Serialize.Export.pas
@@ -349,7 +349,10 @@ begin
             Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONString.Create(FormatCurr(TDataSetSerializeConfig.GetInstance.Export.FormatCurrency, LField.AsCurrency)));
         end;
       TFieldType.ftFMTBcd, TFieldType.ftBCD:
-        Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}BcdToDouble(LField.AsBcd){$ELSE}TJSONNumber.Create(BcdToDouble(LField.AsBcd)){$ENDIF});
+         if TDataSetSerializeConfig.GetInstance.Export.ExportBCDAsFloat then
+            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}TJSONExtFloatNumber.Create(BcdToDouble(LField.AsBcd)){$ELSE}TJSONNumber.Create(BcdToDouble(LField.AsBcd)){$ENDIF})
+          else
+            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, {$IF DEFINED(FPC)}BcdToDouble(LField.AsBcd){$ELSE}TJSONNumber.Create(BcdToDouble(LField.AsBcd)){$ENDIF});
       {$IF NOT DEFINED(FPC)}
       TFieldType.ftDataSet:
         begin


### PR DESCRIPTION
Created 2 new properties to export:
1 - ExportLargeintAsString: I use a snowflake implementation to generate ids and this is a number int64 like 197688037381099177. In browsers and javascript this int64 is broken. I created a property to export largeint like a string;
2 - ExportBCDAsFloat: In my firebird database I have a column decimal 10,3. In json 5.00 is write 5.0000000000000000E+001. I create a property to export BCD as float number.