### PR TITLE
encode64 verify on import blob field content

### DIFF
--- a/src/DataSet.Serialize.Import.pas
+++ b/src/DataSet.Serialize.Import.pas
@@ -604,18 +604,22 @@ begin
   LStringStream := TStringStream.Create((AJSONValue as TJSONString).Value);
   try
     LStringStream.Position := 0;
-    {$IF DEFINED(FPC)}
-    TBlobField(AField).AsString := DecodeStringBase64(LStringStream.DataString);
-    {$ELSE}
-    LMemoryStream := TMemoryStream.Create;
-    try
-      TNetEncoding.Base64.Decode(LStringStream, LMemoryStream);
-      LMemoryStream.Position := 0;
-      TBlobField(AField).LoadFromStream(LMemoryStream);
-    finally
-      LMemoryStream.Free;
-    end;
-    {$ENDIF}
+    if TDataSetSerializeUtils.IsValidBase64EncodedString(LStringStream.DataString) then
+    begin
+      {$IF DEFINED(FPC)}
+      TBlobField(AField).AsString := DecodeStringBase64(LStringStream.DataString);
+      {$ELSE}
+      LMemoryStream := TMemoryStream.Create;
+      try
+        TNetEncoding.Base64.Decode(LStringStream, LMemoryStream);
+        LMemoryStream.Position := 0;
+        TBlobField(AField).LoadFromStream(LMemoryStream);
+      finally
+        LMemoryStream.Free;
+      end;
+      {$ENDIF}
+    end else
+      TBlobField(AField).AsString := LStringStream.DataString;
   finally
     LStringStream.Free;
   end;

--- a/src/DataSet.Serialize.Utils.pas
+++ b/src/DataSet.Serialize.Utils.pas
@@ -120,6 +120,10 @@ type
     ///   Return in ADataSetDetails all child datasets of ADataSet (Master dataset)
     /// </summary>
     class procedure GetDetailsDatasets(const ADataSet: TDataSet; ADataSetDetails: TList<TDataSet>);
+    /// <summary>
+    ///   Return if a string is a valid encoded base64
+    /// </summary>
+    class function IsValidBase64EncodedString(const AValue: string): Boolean;
   end;
 
 implementation
@@ -263,6 +267,29 @@ begin
   {$ELSE}
   ADataSet.GetDetailDataSets(ADataSetDetails);
   {$ENDIF}
+end;
+
+class function TDataSetSerializeUtils.IsValidBase64EncodedString(
+  const AValue: string): Boolean;
+const
+  Base64Alphabet = ['A'..'Z', 'a'..'z', '0'..'9', '+', '/'];
+var
+  I: Integer;
+  LSize: Integer;
+begin
+  LSize := Length(AValue);
+  Result := (LSize > 0) and (LSize mod 4 = 0);
+  if Result then
+  begin
+    while (AValue[LSize] = '=') and (LSize > Length(AValue) - 2) do
+      Dec(LSize);
+    for I := LSize downto 1 do
+    if not (AValue[I] in Base64Alphabet) then
+    begin
+      Result := False;
+      Break;
+    end;
+  end;
 end;
 
 class function TDataSetSerializeUtils.NewDataSetField(const ADataSet: TDataSet; const AFieldStructure: TFieldStructure): TField;


### PR DESCRIPTION
Checks that the content of the blob field is a valid encode64 before decoding. If not, keep the original string.