### PR TITLE
Adicionando opção de exportar string vazia como null

### DIFF
--- a/src/DataSet.Serialize.Config.pas
+++ b/src/DataSet.Serialize.Config.pas
@@ -16,6 +16,7 @@ type
     FExportLargeIntAsString: Boolean;
     FExportNullValues: Boolean;
     FExportNullAsEmptyString: Boolean;
+    FExportEmptyStringAsNull: Boolean;
     FExportOnlyFieldsVisible: Boolean;
     FExportEmptyDataSet: Boolean;
     FFormatCurrency: string;
@@ -38,6 +39,7 @@ type
     property ExportOnlyFieldsVisible: Boolean read FExportOnlyFieldsVisible write FExportOnlyFieldsVisible;
     property ExportNullValues: Boolean read FExportNullValues write FExportNullValues;
     property ExportNullAsEmptyString: Boolean read FExportNullAsEmptyString write FExportNullAsEmptyString;
+    property ExportEmptyStringAsNull: Boolean read FExportEmptyStringAsNull write FExportEmptyStringAsNull;
     property ExportEmptyDataSet: Boolean read FExportEmptyDataSet write FExportEmptyDataSet;
     property ExportChildDataSetAsJsonObject: Boolean read FExportChildDataSetAsJsonObject write FExportChildDataSetAsJsonObject;
     property TryConvertStringToJson: Boolean read FTryConvertStringToJson write FTryConvertStringToJson;
@@ -146,6 +148,7 @@ begin
   FTryConvertStringToJson := False;
   FExportNullValues := True;
   FExportNullAsEmptyString:= False;
+  FExportEmptyStringAsNull := False;
   FExportOnlyFieldsVisible := True;
   ExportEmptyDataSet := False;
   FFormatCurrency := EmptyStr;

--- a/src/DataSet.Serialize.Export.pas
+++ b/src/DataSet.Serialize.Export.pas
@@ -319,7 +319,9 @@ begin
       TFieldType.ftString, TFieldType.ftWideString, TFieldType.ftMemo, TFieldType.ftWideMemo, TFieldType.ftFixedChar, TFieldType.ftFixedWideChar:
         begin
           LStringValue := Trim(LField.AsWideString);
-          if TDataSetSerializeConfig.GetInstance.Export.TryConvertStringToJson then
+          if (LStringValue = EmptyStr) and (TDataSetSerializeConfig.GetInstance.Export.ExportEmptyStringAsNull) then
+            Result.{$IF DEFINED(FPC)}Add{$ELSE}AddPair{$ENDIF}(LKey, TJSONNull.Create())
+          else if TDataSetSerializeConfig.GetInstance.Export.TryConvertStringToJson then
           begin
             if (LStringValue.StartsWith('{') and LStringValue.EndsWith('}')) or (LStringValue.StartsWith('[') and LStringValue.EndsWith(']')) then
             begin


### PR DESCRIPTION
Adicionei uma opção que converte propriedades de string vazia em null nos requests: _**ExportEmptyStringAsNull**_

Essa alteração visa garantir que, quando uma propriedade de um objeto for uma string vazia, ela seja enviada como null.