### PR TITLE
Value not found and not refreshing var

### DIFF
--- a/src/DataSet.Serialize.Import.pas
+++ b/src/DataSet.Serialize.Import.pas
@@ -353,7 +353,8 @@ begin
           Continue;
         {$ELSE}
         if not AJSONObject.TryGetValue(TDataSetSerializeUtils.FormatCaseNameDefinition(LField.FieldName), LJSONValue) then
-          AJSONObject.TryGetValue(LField.FieldName, LJSONValue);
+          if not AJSONObject.TryGetValue(LField.FieldName, LJSONValue) then
+            LJSONValue := nil;
         if not Assigned(LJSONValue) then
         begin
           // In case the JSON key name has dots, the native method TryGetValue doesn't find it


### PR DESCRIPTION
While adding values to the TDataSet, if a field name is not found in the JSON it was preserving the last LJSONValue and reusing its value to the new field (when it needed to be NIL-NULL)